### PR TITLE
Mantain line sequence and character count, correct AutoFix from VsCode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ function padContent (node: Node, originalInput: string): string {
     
     const nodeContent = originalInput.substring(node.__location.startTag.endOffset, node.__location.endTag.startOffset);
     const preNodeContent = originalInput.substring(0, node.__location.startTag.endOffset);
-    const nodeLocation = (preNodeContent.match(new RegExp("\n", "g")) || []).length + 1;
+    const nodeLocation = (preNodeContent.match(new RegExp('\n', 'g')) || []).length + 1;
 
     const spacePad = Math.floor((node.__location.startTag.endOffset - nodeLocation) / nodeLocation);
     const remainderSlashPad = ((node.__location.startTag.endOffset - nodeLocation) % nodeLocation) + 1
@@ -49,9 +49,9 @@ function padContent (node: Node, originalInput: string): string {
  * Return a string of slashes the size of the given amount.
  */
 function createPaddingSlashes(amount: number): string {
-    var slashPadding = ''
-    for(var x = 0; x < amount; x++){
-        slashPadding += "/"
+    let slashPadding = ''
+    for (let x = 0; x < amount; x++) {
+        slashPadding += '/';
     }
     return slashPadding;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ function padContent (node: Node, originalInput: string): string {
  */
 function createPaddingSlashes(amount: number): string {
     var slashPadding = ''
-    for(var x=0; x < amount; x++){
+    for(var x = 0; x < amount; x++){
         slashPadding += "/"
     }
     return slashPadding;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ function padContent (node: Node, originalInput: string): string {
 }
 
 /**
- * Get an array of all the nodes (tags).
+ * Return a string of slashes the size of the given amount.
  */
 function createPaddingSlashes(amount: number): string {
     var slashPadding = ''


### PR DESCRIPTION
Mantain line sequence and character count to let linters inform correctly about error locations.
TSLint as an example when informing vscode-tslint-vue from error location it does so by using line offsets.

This makes it require that line count and character count must match perfectly against the original document.
This also requires that Line ending format (LF/CRLF) is not modified or at least compensated.

Unluckly parse5.parse() tended to transform CRLF code to LF and distorted the line offset, text is now simply extracted from substring() to keep line sequence.

The upper content from the Vue file like template tag is replaced by slashes that match the character count.

I have tested it on Visual Studio Code using both CRLF and LF line sequence. This fixes AutoFix functionality on VsCode which without this when applying the fixes would modify a completely difference area of the document