### PR TITLE
Support Src Imports

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -94,4 +94,10 @@ describe('Tests', function () {
     expect(parsed).to.be.equal('// tslint:disable\nimport Vue from \'vue\'\nexport default Vue\n')   
   })
 
+  it('should return import/export statements if imports external file', function() {
+    const contents = fs.readFileSync('./test/test-src-imports.vue', 'utf8')
+    const parsed = vueParser.parse(contents, 'script', { lang: 'ts' })
+
+    expect(parsed).to.be.equal('// tslint:disable\n//\n//\n//\nexport { default } from \'./index\'')
+  })
 })

--- a/test/test-src-imports.vue
+++ b/test/test-src-imports.vue
@@ -1,0 +1,5 @@
+<template>
+  <h1>vue-parser</h1>
+</template>
+
+<script lang='ts' src='./index.ts'></script>


### PR DESCRIPTION
This PR is to support [Src Imports](https://vue-loader.vuejs.org/spec.html#src-imports) in .vue

## example code

```ts
const parser = require('vue-parser')

const content = `<template>
  <div class='hoge'>
  </div>
</template>
<script lang='ts' src='./index.ts'></script>
`;

console.log(parser.parse(content, 'script', {lang: ['ts']}, {emptyExport: true}))

```

## Before

```
// tslint:disable
//
//
//
                                             // tslint:enable
```

## After 

```
// tslint:disable
//
//
//
export { default } from './index'
```
